### PR TITLE
Add GitHub Actions workflow to publish per-PR demo previews on GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,96 @@
+name: Pull Request Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build demo
+        run: npm run build
+
+      - name: Add preview notice
+        env:
+          PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          cat > examples/dist/preview.json <<JSON
+          {
+            "previewUrl": "${PREVIEW_URL}",
+            "sourceSha": "${SOURCE_SHA}"
+          }
+          JSON
+
+      - name: Deploy preview to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: examples/dist
+          destination_dir: pr-${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+        with:
+          script: |
+            const marker = '<!-- pr-preview-url -->';
+            const body = `${marker}\n🚀 Pull Request preview is ready:\n\n${process.env.PREVIEW_URL}\n\nOpen this URL from a phone or another device to verify the demo before merging.`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const previous = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove preview from GitHub Pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete preview directory
+        run: |
+          rm -rf pr-${{ github.event.pull_request.number }}
+          if git diff --quiet; then
+            echo "No preview directory to remove."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A pr-${{ github.event.pull_request.number }}
+          git commit -m "Remove PR #${{ github.event.pull_request.number }} preview"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ export default App;
 
 ```
 
+## Pull Request Preview
+
+When a pull request is opened, updated, or reopened, GitHub Actions builds the demo and publishes a temporary preview to GitHub Pages. The workflow comments the preview URL on the pull request, so reviewers can open the demo from a desktop browser or smartphone before merging.
+
+Preview URLs use the following format:
+
+```text
+https://<owner>.github.io/<repository>/pr-<pull-request-number>/
+```
+
+The preview directory is removed automatically when the pull request is closed.
+


### PR DESCRIPTION
### Motivation

- Allow reviewers to open and verify the demo online (including from smartphones) at pull request time without merging. 
- Existing project already publishes a demo site, so add a per-PR preview flow that publishes builds under `pr-<number>` on GitHub Pages.

### Description

- Add a new workflow ` .github/workflows/pr-preview.yml` that builds the demo on PR `opened`, `synchronize`, and `reopened` and deploys `examples/dist` to `gh-pages` under `pr-<pull-request-number>` using `peaceiris/actions-gh-pages@v4`.
- The workflow writes a `examples/dist/preview.json` with `previewUrl` and `sourceSha` and posts or updates a PR comment with the preview URL using `actions/github-script@v7`.
- Add a `cleanup-preview` job that runs when the PR is closed and removes the `pr-<number>` directory from the `gh-pages` branch to avoid stale previews.
- Update `README.md` with a `Pull Request Preview` section documenting the preview URL format and lifecycle.

### Testing

- Ran `npm run build` locally and the build completed successfully (webpack emitted warnings about bundle size but the build succeeded).
- Verified the workflow YAML parses with `ruby -e 'require "psych"; Psych.load_file(".github/workflows/pr-preview.yml")'`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a30669624832db98ee1d08291d76f)