### PR TITLE
Fix threshold-based document search and refactor Excel/tokenization flow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,200 +4,214 @@ import './styles.css';
 import { distance } from 'fastest-levenshtein';
 import { trigram } from 'n-gram';
 
+const DEFAULT_THRESHOLD = 1;
+const DEFAULT_KEYS = ['検索対象を選ぶ'];
+
 class ReactPoorSearch extends React.Component {
     constructor(props) {
         super(props);
+
+        this.fileInput = React.createRef();
         this.state = {
             hitItems: [],
-            fileInput: {
-                current: null
-            },
-            fileName: "",
+            fileName: '',
             excelData: [],
-            searchTarget: "question",
-            keys: ["検索対象を選ぶ"],
+            searchKeyword: '',
+            searchTarget: '',
+            keys: DEFAULT_KEYS,
             tokenizedExcelData: [],
+            threshold: this.getInitialThreshold(props),
         };
+
         this.handleChange = this.handleChange.bind(this);
+        this.handleReadFile = this.handleReadFile.bind(this);
+        this.handleSearchTargetChange = this.handleSearchTargetChange.bind(this);
+        this.handleTriggerReadFile = this.handleTriggerReadFile.bind(this);
+    }
+
+    getInitialThreshold(props) {
+        if (typeof props.threshold === 'number') {
+            return props.threshold;
+        }
+        return DEFAULT_THRESHOLD;
     }
 
     handleChange(event) {
-        this.setState({
-            hitItems: this.searchDocs(event.target.value.toLowerCase())
+        const searchKeyword = event.target.value;
+
+        this.setState((prevState) => ({
+            searchKeyword,
+            hitItems: this.searchDocs(searchKeyword, prevState),
+        }));
+    }
+
+    handleSearchTargetChange(event) {
+        const searchTarget = event.target.value;
+
+        this.setState((prevState) => {
+            const nextState = {
+                ...prevState,
+                searchTarget,
+            };
+
+            return {
+                searchTarget,
+                hitItems: this.searchDocs(prevState.searchKeyword, nextState),
+            };
         });
     }
 
     handleTriggerReadFile() {
-        if (this.state.fileInput.current) {
-            this.state.fileInput.current.click();
+        if (this.fileInput.current) {
+            this.fileInput.current.click();
         }
-    };
+    }
 
     handleReadFile(fileObj) {
-        if (fileObj) {
-            this.setState({ fileName: fileObj.name })
-            fileObj.arrayBuffer().then((buffer) => {
-                const workbook = read(buffer, { type: 'buffer', bookVBA: true })
-                const firstSheetName = workbook.SheetNames[0]
-                const worksheet = workbook.Sheets[firstSheetName]
-                const data = utils.sheet_to_json(worksheet)
-                this.setState({ excelData: data })
-                this.setState({ keys: Object.keys(data[0]) })
-                this.setState({ searchTarget: Object.keys(data[0])[0] })
-
-                var tokenizedExcelData = new Array();
-                var kanjiOnlyExcelData = new Array();
-                data.map((doc) => {
-                    var tokenizedDoc = new Object();
-                    var kanjiOnlyDoc = new Object();
-                    var key = Object.keys(doc)
-                    key.map((k) => {
-                        tokenizedDoc[k] = this.tokenizeText(doc[k])
-                        kanjiOnlyDoc[k] = this.extract_kanji(doc[k])
-                    })
-                    tokenizedExcelData.push(tokenizedDoc)
-                    kanjiOnlyExcelData.push(kanjiOnlyDoc)
-                })
-                this.setState({ tokenizedExcelData: tokenizedExcelData })
-                this.setState({ kanjiOnlyExcelData: kanjiOnlyExcelData })
-            })
+        if (!fileObj) {
+            return;
         }
+
+        this.setState({ fileName: fileObj.name });
+        fileObj.arrayBuffer().then((buffer) => {
+            const workbook = read(buffer, { type: 'buffer', bookVBA: true });
+            const firstSheetName = workbook.SheetNames[0];
+            const worksheet = workbook.Sheets[firstSheetName];
+            const data = utils.sheet_to_json(worksheet);
+            const keys = this.extractKeys(data);
+            const searchTarget = keys[0] || '';
+            const tokenizedExcelData = data.map((doc) => this.tokenizeDocument(doc, keys));
+
+            this.setState((prevState) => {
+                const nextState = {
+                    ...prevState,
+                    excelData: data,
+                    keys: keys.length > 0 ? keys : DEFAULT_KEYS,
+                    searchTarget,
+                    tokenizedExcelData,
+                };
+
+                return {
+                    excelData: data,
+                    keys: keys.length > 0 ? keys : DEFAULT_KEYS,
+                    searchTarget,
+                    tokenizedExcelData,
+                    hitItems: this.searchDocs(prevState.searchKeyword, nextState),
+                };
+            });
+        });
+    }
+
+    extractKeys(data) {
+        if (data.length === 0) {
+            return [];
+        }
+        return Object.keys(data[0]);
+    }
+
+    tokenizeDocument(doc, keys) {
+        return keys.reduce((tokenizedDoc, key) => {
+            tokenizedDoc[key] = this.tokenizeText(doc[key]);
+            return tokenizedDoc;
+        }, {});
     }
 
     selectMenu() {
-        return (
-            this.state.keys.map((key) => {
-                return <option value={key}>{key}</option>
-            })
-        );
+        return this.state.keys.map((key) => (
+            <option value={key} key={key}>{key}</option>
+        ));
     }
 
-    searchDocs(keyword) {
-        const threshold = 1;
+    searchDocs(keyword, state = this.state) {
+        const keywords = this.tokenizeText(keyword);
 
-        const kjScores = this.kanjiSearch(keyword)
-        const keywords = this.tokenizeText(keyword)
-        const scores = [];
-        const isHit = this.state.tokenizedExcelData.map((doc, idx) => {
-            var targetDoc = doc[this.state.searchTarget]
-            var dists = [];
-            var hitDoc = targetDoc.filter((sent, _) => {
-                keywords.map((keySent, _) => {
-                    dists.push(distance(sent, keySent));
-                })
-                if (this.calcMin(dists) <= threshold || kjScores[idx] == 0) {
-                    return true
-                }
-            })
-            scores.push({ index: idx, score: this.calcMin(dists), kjscore: kjScores[idx] });
-            if (hitDoc.length > 0) {
-                return true
-            }
-        })
+        if (keywords.length === 0 || !state.searchTarget) {
+            return [];
+        }
 
-        const sortedScores = this.sortScore(scores)
-        const sortedIsHit = sortedScores.map((score, _) => {
-            return isHit[score.index]
-        })
-        const sortedDocs = sortedScores.map((score, _) => {
-            return this.state.excelData[score.index]
-        })
-
-        const hitDocs = sortedDocs.filter((_, index) => {
-            return sortedIsHit[index]
-        })
-        return hitDocs
+        return state.tokenizedExcelData
+            .map((doc, index) => ({
+                index,
+                score: this.calculateDocumentScore(doc[state.searchTarget], keywords),
+            }))
+            .filter(({ score }) => score <= state.threshold)
+            .sort((a, b) => a.score - b.score)
+            .map(({ index }) => state.excelData[index]);
     }
 
-    kanjiSearch(keyword) {
-        const kjKeyword = this.extract_kanji(keyword)
-        const kjHitDocs = this.state.kanjiOnlyExcelData.map((doc, _) => {
-            var targetDoc = doc[this.state.searchTarget]
-            if (targetDoc.search(kjKeyword) !== -1) {
-                return 0
-            } else {
-                return 1
-            }
-        })
-        return kjHitDocs;
+    calculateDocumentScore(targetTokens = [], keywordTokens) {
+        const distances = [];
+
+        keywordTokens.forEach((keywordToken) => {
+            targetTokens.forEach((targetToken) => {
+                distances.push(distance(targetToken, keywordToken));
+            });
+        });
+
+        return this.calcMin(distances);
     }
 
     calcMin(list) {
-        if (list.length > 0) {
-            return list.reduce((a, b) => Math.min(a, b))
+        if (list.length === 0) {
+            return Infinity;
         }
-        return list
-    }
-
-    sortScore(list) {
-        list.sort(function (a, b) {
-            if (a.kjscore != b.kjscore) {
-                if (a.kjscore < b.kjscore) {
-                    return -1;
-                }
-                if (a.kjscore > b.kjscore) {
-                    return 1;
-                }
-            }
-            if (a.score != b.score) {
-                return a.score - b.score;
-            }
-            return 0;
-        });
-        return list;
+        return list.reduce((a, b) => Math.min(a, b));
     }
 
     renderTableCell(item) {
-        return this.state.keys.map((key) => {
-            return (
-                <th className="item">
-                    {item[key]}
-                </th>
-            );
-        })
+        return this.state.keys.map((key) => (
+            <td className="item" key={key}>
+                {item[key]}
+            </td>
+        ));
     }
 
     renderTableComponent(items) {
-        return items.map((item, index) => {
-            return (
-                <tr key={index}>
-                    {this.renderTableCell(item)}
-                </tr>)
-        });
+        return items.map((item, index) => (
+            <tr key={index}>
+                {this.renderTableCell(item)}
+            </tr>
+        ));
     }
 
     renderTableCellHeader() {
-        return this.state.keys.map((key) => {
-            return (
-                <th className="header">
-                    {key}
-                </th>
-            );
-        })
+        return this.state.keys.map((key) => (
+            <th className="header" key={key}>
+                {key}
+            </th>
+        ));
     }
 
     renderTable(items) {
         return (
             <table className="items">
-                <tr key="header">
-                    {this.renderTableCellHeader()}
-                </tr>
-                {this.renderTableComponent(items)}
+                <thead>
+                    <tr>
+                        {this.renderTableCellHeader()}
+                    </tr>
+                </thead>
+                <tbody>
+                    {this.renderTableComponent(items)}
+                </tbody>
             </table>
         );
     }
 
     tokenizeText(text) {
-        return trigram(text)
+        const normalizedText = this.normalizeText(text);
+        if (normalizedText.length === 0) {
+            return [];
+        }
+
+        const tokens = trigram(normalizedText);
+        return tokens.length > 0 ? tokens : [normalizedText];
     }
 
-    extract_kanji(text) {
-        const regexp = /([\u{3005}\u{3007}\u{303b}\u{3400}-\u{9FFF}\u{F900}-\u{FAFF}\u{20000}-\u{2FFFF}][\u{E0100}-\u{E01EF}\u{FE00}-\u{FE02}]?)/mug;
-        const res = text.match(regexp)
-        if (res !== null) {
-            return res.join("")
+    normalizeText(text) {
+        if (text === null || typeof text === 'undefined') {
+            return '';
         }
-        return ""
+        return String(text).toLowerCase();
     }
 
     render() {
@@ -205,7 +219,8 @@ class ReactPoorSearch extends React.Component {
             <div>
                 <div className="">
                     <select
-                        onChange={(e) => this.setState({ searchTarget: e.target.value })}
+                        value={this.state.searchTarget || this.state.keys[0]}
+                        onChange={this.handleSearchTargetChange}
                         className="styled-select"
                     >
                         {this.selectMenu()}
@@ -216,17 +231,17 @@ class ReactPoorSearch extends React.Component {
                 </form>
                 <h3 className="subtitle">ヒットしたデータ一覧</h3>
                 {this.renderTable(this.state.hitItems)}
-                <button className="btn btn-border" onClick={() => this.handleTriggerReadFile()}>
+                <button className="btn btn-border" onClick={this.handleTriggerReadFile}>
                     Import
                 </button>
                 <form style={{ display: 'none' }}>
                     <input
                         type="file"
                         accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                        ref={this.state.fileInput}
+                        ref={this.fileInput}
                         onChange={(e) => {
-                            e.preventDefault()
-                            this.handleReadFile(e.currentTarget.files[0])
+                            e.preventDefault();
+                            this.handleReadFile(e.currentTarget.files[0]);
                         }}
                     />
                 </form>

--- a/src/styles.css
+++ b/src/styles.css
@@ -121,7 +121,7 @@ table.items {
     border-spacing: 0;
     margin: 10% auto;
 }
-th.item {
+td.item {
     border-bottom: 2px solid #c5c5c5;
     text-align: left;
     padding: 5px;


### PR DESCRIPTION
### Motivation
- The previous implementation returned documents via an ad-hoc Kanji substring shortcut, causing results that exceeded the configured Levenshtein `threshold` to still be considered hits.
- The search and Excel-loading code had multiple state updates, fragile null/undefined handling, and confusing iteration patterns that reduced readability and correctness.

### Description
- Enforce threshold-based filtering by computing an n-gram tokenization score per document and returning only documents whose score is `<=` the configured `threshold` stored in component state (`src/index.js`).
- Remove the Kanji-substring shortcut and the old multi-path scoring logic so matching is governed by the Levenshtein score over n-gram tokens (`src/index.js`).
- Refactor Excel loading and tokenization: use a single `setState` update after reading the sheet, extract `extractKeys`/`tokenizeDocument` helpers, and use `React.createRef()` for the file input (`src/index.js`).
- Improve robustness of tokenization by normalizing cell values with `normalizeText`, falling back to the raw normalized string when `trigram` returns no tokens, and replace `flatMap` with explicit loops for broader compatibility (`src/index.js`).
- Fix table markup to use `thead`/`tbody` and `td` cells and update CSS selector to `td.item` to match rendering (`src/index.js`, `src/styles.css`).

### Testing
- Ran `npm run transpile` successfully and verified Babel output.
- Ran `npm run build` successfully; webpack compilation completed with existing bundle-size warnings but no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa344e824832d9788067c642ef609)