### PR TITLE
Auto bump patch version in PR workflow

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -6,21 +6,26 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   version-check:
     runs-on: ubuntu-latest
     steps:
-      # 1. リポジトリをフルフェッチ
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      # 1. PR の head ブランチをフルフェッチ
+      - name: Checkout pull request branch
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # 2. main ブランチの package.json を一時ファイルに取得
+      # 2. ベースブランチの package.json を一時ファイルに取得
       - name: Fetch base package.json
         run: |
-          git fetch origin main
-          git show origin/main:package.json > package.base.json
+          git fetch https://github.com/${{ github.repository }}.git ${{ github.base_ref }}
+          git show FETCH_HEAD:package.json > package.base.json
 
       # 3. ベース／ヘッドのバージョンを取得
       - name: Read versions
@@ -30,11 +35,33 @@ jobs:
           HEAD=$(node -p "require('./package.json').version")
           echo "BASE_VERSION=$BASE" >> $GITHUB_OUTPUT
           echo "HEAD_VERSION=$HEAD" >> $GITHUB_OUTPUT
-
-      # 4. バージョン差分チェック。差分なければエラー出力＆終了コード 1
-      - name: Ensure version is bumped
-        run: |
-          if [ "${{ steps.versions.outputs.BASE_VERSION }}" = "${{ steps.versions.outputs.HEAD_VERSION }}" ]; then
-            echo "::error file=package.json::Version not bumped (still ${{ steps.versions.outputs.HEAD_VERSION }})"
-            exit 1
+          if [ "$BASE" = "$HEAD" ]; then
+            echo "NEEDS_BUMP=true" >> $GITHUB_OUTPUT
+          else
+            echo "NEEDS_BUMP=false" >> $GITHUB_OUTPUT
           fi
+
+      # 4. バージョンが未更新の場合はパッチバージョンを自動インクリメント
+      - name: Auto bump patch version
+        if: steps.versions.outputs.NEEDS_BUMP == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          npm version patch --no-git-tag-version --no-commit-hooks --ignore-scripts
+          UPDATED=$(node -p "require('./package.json').version")
+          echo "Patch version bumped from ${{ steps.versions.outputs.HEAD_VERSION }} to ${UPDATED}."
+
+      # 5. 自動インクリメントした差分を PR ブランチへ push
+      - name: Commit and push version bump
+        if: steps.versions.outputs.NEEDS_BUMP == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump patch version"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      # 6. フォークからの PR は権限上 push できないため、手動更新を促して失敗させる
+      - name: Fail when version cannot be auto bumped
+        if: steps.versions.outputs.NEEDS_BUMP == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error file=package.json::Version not bumped (still ${{ steps.versions.outputs.HEAD_VERSION }}). This workflow cannot push to forked pull requests, so please bump the patch version manually."
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sashimimochi/react-poor-search",
-  "version": "0.2.35",
+  "version": "0.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sashimimochi/react-poor-search",
-      "version": "0.2.35",
+      "version": "0.2.37",
       "license": "Apache-2.0",
       "dependencies": {
         "fastest-levenshtein": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sashimimochi/react-poor-search",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "React component for the poor search engine",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Prevent pull requests from failing solely because the `package.json` version was not bumped, by automatically incrementing the patch version when possible.
- Keep major/minor changes manual while allowing safe automatic patch bumps for same-repository PRs.
- Make behavior explicit for forked PRs which cannot be updated by the workflow due to permission limits.

### Description
- Updated `.github/workflows/check-version.yml` to request `contents: write` permission and check out the PR head branch using `actions/checkout@v4` so the workflow can push changes back to the PR branch.
- Fetch the base branch `package.json` via `git fetch https://github.com/${{ github.repository }}.git ${{ github.base_ref }}` and expose `NEEDS_BUMP` when base and head versions match.
- Added an `Auto bump patch version` step that runs `npm version patch --no-git-tag-version --no-commit-hooks --ignore-scripts` and records the updated version.
- Added a commit-and-push step to push `package.json`/`package-lock.json` back to the PR for same-repository PRs, and an explicit failure step for forked PRs that cannot be auto-updated.

### Testing
- Verified workflow snippets with a `python3` check that ensures required lines are present and consistent, which succeeded.
- Ran `npm run transpile` to ensure project build step still succeeds, which completed successfully.
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/check-version.yml')"` to validate YAML syntax, which succeeded.
- Ran `git diff --check` to ensure no whitespace/format issues, which returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab3e96174832daf5714fabd58efb7)