### PR TITLE
Add npm override to force sockjs -> uuid@14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
     "fastest-levenshtein": "^1.0.12",
     "n-gram": "^2.0.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+  },
+  "overrides": {
+    "sockjs": {
+      "uuid": "14.0.0"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Dependabot attempted to update `uuid` to `14.0.0` but `webpack-dev-server@5.2.4` pulls in `sockjs@0.3.24` which requires `uuid@^8.3.2`, causing `security_update_not_possible` on the transitive dependency.

### Description
- Add an npm `overrides` entry to `package.json` that forces `sockjs` to resolve its `uuid` dependency to `14.0.0` so the security update can be satisfied without changing `webpack-dev-server` at this time.
- Leave `webpack-dev-server` version range (`^5.2.4`) unchanged and resolve the conflict at the npm overrides level.

### Testing
- Validated `package.json` parses with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`, which succeeded.
- Verified the new `overrides` field is present with `npm pkg get devDependencies.webpack-dev-server dependencies.sockjs overrides`, which returned the expected values.
- Attempted to update the lockfile with `npm install --package-lock-only --ignore-scripts` but this could not complete in the current environment because registry access to `https://registry.npmjs.org/uuid` returned `403/connection` errors; lockfile update should be run in an environment with registry access and will update `package-lock.json` accordingly.
- Recommended follow-up commands to run locally or in CI with network access: `npm install --package-lock-only --ignore-scripts`, then `npm install`, then `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291e4adc5c832d8b5cfb32e1df5c95)